### PR TITLE
IAT-2426: Updated the version of tabulator.  The new version is v3.4.1

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -13,10 +13,10 @@ VOLUME ["/tmp"]
 
 COPY ap-ivs.jar /
 
-COPY cpt3.2.0.2.tar.gz /
+COPY cpt3.4.1.tar.gz /
 
-RUN tar xf cpt3.2.0.2.tar.gz
-RUN rm cpt3.2.0.2.tar.gz
+RUN tar xf cpt3.4.1.tar.gz
+RUN rm cpt3.4.1.tar.gz
 RUN mv ./publish ./cpt
 
 RUN apt-get update

--- a/src/main/docker/README.md
+++ b/src/main/docker/README.md
@@ -24,12 +24,12 @@ The gz is a self contained dotnet core application built for a Debian based dock
 
 1. Clone the tabulator project: `git clone https://github.com/SmarterApp/TabulateSmarterTestContentPackage`
 1. Find the commit/branch/tag for the tabulator version you want to incorporate.   
-1. Checkout the version of the code to incorporate, for example: `git checkout hotfix/2018-06`
+1. Checkout the version of the code to incorporate, for example: `git checkout v3.4.1`
 1. Open terminal and navigate to the root of the tabulator project.
 1. Run `dotnet publish -c Release -r debian.8-x64`
 1. Navigate to where the `publish` folder is, for example if you navigate from the root of the tabulator project
  `cd bin/Release/netcoreapp2.0/debian.8-x64` as the `publish` folder is in folder `debian.8-x64`
-1. Run `tar -zcvf cpt<version>.tar.gz publish` -> example `tar -zcvf cpt3.2.0.tar.gz publish`
+1. Run `tar -zcvf cpt<version>.tar.gz publish` -> example `tar -zcvf cpt3.4.1.tar.gz publish`
 1. Copy the gz file to the IVS `src/main/docker` folder.
 1. Navigate to the IVS `src/main/docker` folder
 1. Delete any existing gz files.


### PR DESCRIPTION
IAT-2426

Summary
* Cloned https://github.com/SmarterApp/TabulateSmarterTestContentPackage.git
* Checked out  v3.4.1
* Built the app `dotnet publish -c Release -r debian.8-x64`
* `cd TabulateSmarterTestContentPackage/bin/Release/netcoreapp2.0/debian.8-x64`
* `tar -zcvf cpt3.4.1.tar.gz publish`
* Replaced the existing gz and replaced it with the new one
* The new gz gets built into the docker image and used by the validation service

