### PR TITLE
Feature/iat 2603

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -3,11 +3,11 @@
 #
 # Spring boot uses this file when the application is launched
 # with the root of the project set as the working directory.
-# These properties take precendence over the classpath
+# These properties take precedence over the classpath
 # application.yml.
 #
 # Using gradle from the commandline means the working
-# directory is by defaul the project root.
+# directory is by default the project root.
 #
 # Using Intellij you need to setup your run config so the
 # working directory is the project root.

--- a/src/main/java/org/opentestsystem/ap/ivs/IvsConfiguration.java
+++ b/src/main/java/org/opentestsystem/ap/ivs/IvsConfiguration.java
@@ -1,9 +1,10 @@
-package org.opentestsystem.ap.ivs.config;
+package org.opentestsystem.ap.ivs;
 
 import lombok.Getter;
 import org.opentestsystem.ap.common.config.ItemBankProperties;
 import org.opentestsystem.ap.common.task.ItemCleanupTask;
 import org.opentestsystem.ap.common.task.TaskProperties;
+import org.opentestsystem.ap.ivs.IvsProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,18 +14,13 @@ import org.springframework.context.annotation.Configuration;
  */
 
 @Configuration
-public class IvsConfig {
+public class IvsConfiguration {
 
     private final ItemBankProperties itemBankProperties;
 
-    @Getter
-    private final IvsProperties ivsProperties;
-
     @Autowired
-    public IvsConfig(ItemBankProperties itemBankProperties,
-                     IvsProperties ivsProperties) {
+    public IvsConfiguration(ItemBankProperties itemBankProperties) {
         this.itemBankProperties = itemBankProperties;
-        this.ivsProperties = ivsProperties;
     }
 
     @Bean

--- a/src/main/java/org/opentestsystem/ap/ivs/IvsProperties.java
+++ b/src/main/java/org/opentestsystem/ap/ivs/IvsProperties.java
@@ -1,16 +1,17 @@
-package org.opentestsystem.ap.ivs.config;
+package org.opentestsystem.ap.ivs;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
 
 @Getter
 @Setter
-@Configuration
+@Component
 @ConfigurationProperties(prefix = "ivs")
 public class IvsProperties {
 

--- a/src/main/java/org/opentestsystem/ap/ivs/config/IvsConfig.java
+++ b/src/main/java/org/opentestsystem/ap/ivs/config/IvsConfig.java
@@ -1,7 +1,11 @@
 package org.opentestsystem.ap.ivs.config;
 
 import lombok.Getter;
+import org.opentestsystem.ap.common.config.ItemBankProperties;
+import org.opentestsystem.ap.common.task.ItemCleanupTask;
+import org.opentestsystem.ap.common.task.TaskProperties;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -11,11 +15,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class IvsConfig {
 
-    @Autowired
-    public IvsConfig(final IvsProperties ivsProperties) {
-        this.ivsProperties = ivsProperties;
-    }
+    private final ItemBankProperties itemBankProperties;
 
     @Getter
     private final IvsProperties ivsProperties;
+
+    @Autowired
+    public IvsConfig(ItemBankProperties itemBankProperties,
+                     IvsProperties ivsProperties) {
+        this.itemBankProperties = itemBankProperties;
+        this.ivsProperties = ivsProperties;
+    }
+
+    @Bean
+    public ItemCleanupTask itemCleanupTask(TaskProperties taskProperties) {
+        return new ItemCleanupTask(taskProperties, this.itemBankProperties);
+    }
 }

--- a/src/main/java/org/opentestsystem/ap/ivs/service/ValidationService.java
+++ b/src/main/java/org/opentestsystem/ap/ivs/service/ValidationService.java
@@ -17,7 +17,7 @@ import org.opentestsystem.ap.common.repository.ItemCrudRequest;
 import org.opentestsystem.ap.common.repository.ItemRepository;
 import org.opentestsystem.ap.common.util.RandomIdGenerator;
 import org.opentestsystem.ap.common.util.SecurityUtil;
-import org.opentestsystem.ap.ivs.config.IvsProperties;
+import org.opentestsystem.ap.ivs.IvsProperties;
 import org.opentestsystem.ap.ivs.models.ErrorReport;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/org/opentestsystem/ap/ivs/service/ValidationUtility.java
+++ b/src/main/java/org/opentestsystem/ap/ivs/service/ValidationUtility.java
@@ -20,7 +20,7 @@ import org.opentestsystem.ap.common.exception.SystemException;
 import org.opentestsystem.ap.common.model.Item;
 import org.opentestsystem.ap.common.model.ItemContext;
 import org.opentestsystem.ap.common.repository.RepositoryUtil;
-import org.opentestsystem.ap.ivs.config.IvsProperties;
+import org.opentestsystem.ap.ivs.IvsProperties;
 import org.opentestsystem.ap.ivs.models.ErrorReport;
 import org.springframework.stereotype.Component;
 

--- a/src/test/java/org/opentestsystem/ap/ivs/TestHelper.java
+++ b/src/test/java/org/opentestsystem/ap/ivs/TestHelper.java
@@ -13,7 +13,6 @@ import org.opentestsystem.ap.common.saaif.SaaifMetadataAssembler;
 import org.opentestsystem.ap.common.saaif.SaaifWordListAssembler;
 import org.opentestsystem.ap.common.saaif.ValidationResultAssembler;
 import org.opentestsystem.ap.common.util.RandomIdGenerator;
-import org.opentestsystem.ap.ivs.config.IvsProperties;
 
 import java.io.BufferedOutputStream;
 import java.io.File;


### PR DESCRIPTION
IAT-2603

It was discovered in production the validation service is evicted fairly often.  Looking into it revealed there is no clean up job running for the service.  The disk filled up and the pod was evicted.  The configuration for the job was missed when moving the reusable configuration into common.  

Adding the clean up task as a bean in the validation service configuration is all that was needed.

Below I made a few changes related to project structure.  