### PR TITLE
Prepare service for running docker-compose and CI environments

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -15,52 +15,6 @@
 server:
   port: 8087
 
-security:
-  basic:
-    enabled: "${SECURITY_ENABLED:true}"
-  user:
-    name: "admin"
-    password: "admin"
-
-spring:
-  session:
-    enabled: "${SESSION_CLUSTER_ENABLED:true}"
-  datasource:
-    url: "jdbc:postgresql://localhost:5432/iat"
-    username: "${DB_USER}"
-    password: "${DB_PASSWORD}"
-    validationQuery: "SELECT 1"
-  jpa:
-    hibernate:
-      ddl-auto: "validate"
-    properties:
-      hibernate:
-        show_sql: true
-        use_sql_comments: true
-        format_sql: true
-
-itembank:
-  localBaseDir: "${HOME}/ItemBankValidation"
-  systemUser:
-    userName: "iat-item-validation-service@smarterbalanced.org"
-    fullName: "Item Validation Service"
-  enabled:
-    database: true
-  services:
-    history:
-      url: "http://localhost:8086"
-  aws:
-    endpointUrl: "https://s3.us-east-2.amazonaws.com"
-    region: "us-east-2"
-    bucketName: "${GITLAB_GROUP}"
-    versionedBucketName: "${GITLAB_GROUP}-versioned"
-    accessKey: "${IAT_AWS_ACCESS_KEY}"
-    secretKey: "${IAT_AWS_ACCESS_SECRET}"
-
-tasks:
-  itemCleanupThresholdMillis : "1800000"
-  itemCleanupRunEveryMillis: "1800000"
-
 logging:
   level:
     org:
@@ -68,14 +22,6 @@ logging:
         ap:
           ivs: "debug"
           common: "debug"
-
-ivs:
-  # This path is to the executable version of the CPT appropriate to the machine it's running on.
-  # Currently supported environments are Windows (win10-x64), OSX (osx.10.12-x64), and Debian Linux (debian.8-x64).
-  # Failure to provide an appropriate executable will cause validation to fail. CPT releases
-  # may be found on GitHub here: https://github.com/SmarterApp/TabulateSmarterTestContentPackage/releases
-  cptExecutablePath: "${TABULATOR_HOME:dotnet ${HOME}/tabulator/TabulateSmarterTestContentPackage.dll -v-trd}"
-  disableImmediateCleanup: true
 
 ---
 spring:

--- a/build.gradle
+++ b/build.gradle
@@ -233,16 +233,19 @@ task dockerCopyFiles(type: Copy) {
 task dockerBuildImage(type: DockerBuildImage) {
     dependsOn 'dockerCopyFiles'
     inputDir = project.file('build/docker/')
-    tag = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    tags.add(name.toString())
 }
 
 task dockerPushImage(type: DockerPushImage) {
     dependsOn 'dockerBuildImage'
-    imageName = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageName = name.toString()
 }
 
 task dockerRemoveImage(type: DockerRemoveImage) {
-    imageId = "${project.dockerTagBase}/${jar.baseName}:${project.version}"
+    def name = "${dockerTagBase}/${jar.baseName}" + (project.version.contains('-SNAPSHOT') ? "": ":${project.version}")
+    imageId = name.toString()
 }
 
 /***************************

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -22,6 +22,6 @@ RUN mv ./publish ./cpt
 RUN apt-get update
 RUN apt-get -y install curl libunwind8 gettext apt-transport-https
 
-ENTRYPOINT ["/usr/bin/java"]
+ENV MAX_HEAP_SIZE -Xmx384m
 
-CMD ["-jar", "/ap-ivs.jar"]
+CMD java $MAX_HEAP_SIZE $JAVA_OPTS -jar ap-ivs.jar

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,54 @@ management:
 
 api:
   context-path: "/api"
+
+ivs:
+  # This path is to the executable version of the CPT appropriate to the machine it's running on.
+  # Currently supported environments are Windows (win10-x64), OSX (osx.10.12-x64), and Debian Linux (debian.8-x64).
+  # Failure to provide an appropriate executable will cause validation to fail. CPT releases
+  # may be found on GitHub here: https://github.com/SmarterApp/TabulateSmarterTestContentPackage/releases
+  cptExecutablePath: \${TABULATOR_HOME:dotnet \${HOME}/tabulator/TabulateSmarterTestContentPackage.dll -v-trd}
+  disableImmediateCleanup: true
+
+security:
+  basic:
+    enabled: \${SECURITY_ENABLED:true}
+
+spring:
+  session:
+    enabled: \${SESSION_CLUSTER_ENABLED:true}
+  datasource:
+    url: "jdbc:postgresql://localhost:5432/iat"
+    username: \${DB_USER}
+    password: \${DB_PASSWORD}
+    validationQuery: "SELECT 1"
+  jpa:
+    hibernate:
+      ddl-auto: "validate"
+    properties:
+      hibernate:
+        show_sql: true
+        use_sql_comments: true
+        format_sql: true
+
+itembank:
+  localBaseDir: \${HOME}/ItemBankValidation
+  systemUser:
+    userName: "iat-item-validation-service@smarterbalanced.org"
+    fullName: "Item Validation Service"
+  enabled:
+    database: true
+  services:
+    history:
+      url: "http://localhost:8086"
+  aws:
+    endpointUrl: "https://s3.us-east-2.amazonaws.com"
+    region: "us-east-2"
+    bucketName: \${GITLAB_GROUP}
+    versionedBucketName: \${GITLAB_GROUP}-versioned
+    accessKey: \${IAT_AWS_ACCESS_KEY}
+    secretKey: \${IAT_AWS_ACCESS_SECRET}
+
+tasks:
+  itemCleanupThresholdMillis : "1800000"
+  itemCleanupRunEveryMillis: "1800000"


### PR DESCRIPTION
Sample docker-compose:
```
  # Item Validation Service
  ap-ivs:
    image: fwsbac/ap-ivs:latest
    ports:
      - 8087:8080
    volumes:
      - ${HOME}:/home
    environment:
      - MAX_HEAP_SIZE=-Xmx300m
      - HOME=/home
      - SPRING_REDIS_HOST=host.docker.internal
      - SPRING_RABBITMQ_HOST=host.docker.internal
      - SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal:5432/iat
      - ITEMBANK_SERVICES_HISTORY_URL=http://host.docker.internal:8086
      - SECURITY_ENABLED
      - SESSION_CLUSTER_ENABLED
      - DB_USER
      - DB_PASSWORD
      - GITLAB_GROUP
      - IAT_AWS_ACCESS_KEY
      - IAT_AWS_ACCESS_SECRET
      - TABULATOR_HOME
```